### PR TITLE
update deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
 
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.9.946"]
-                 [org.clojure/core.async  "0.3.465"]
+                 [org.clojure/core.async  "0.4.474"]
                  [org.clojure/spec.alpha "0.1.143"]
                  [cljsjs/vue "2.5.2-0"]]
 
@@ -104,7 +104,7 @@
   ;; Setting up nREPL for Figwheel and ClojureScript dev
   ;; Please see:
   ;; https://github.com/bhauman/lein-figwheel/wiki/Using-the-Figwheel-REPL-within-NRepl
-  :profiles {:dev {:dependencies [[binaryage/devtools "0.9.8"]
+  :profiles {:dev {:dependencies [[binaryage/devtools "0.9.9"]
                                   [figwheel-sidecar "0.5.14"]
                                   [com.cemerick/piggieback "0.2.2"]]
                    ;; need to add dev source path here to get user.clj loaded


### PR DESCRIPTION
This is a trivial version bump to correct the `dependencies out of date` status badge.