### PR TITLE
Fix for default value of :state

### DIFF
--- a/src/glue/core.cljs
+++ b/src/glue/core.cljs
@@ -98,7 +98,7 @@
         :ret ::converted-config)
 
 (defn convert-component-config [{:keys [state data methods computed props]
-                                :or {state {}
+                                :or {state (fn [] {})
                                      data (fn [] {})
                                      methods {}
                                      computed {}

--- a/test/glue/api_test.cljs
+++ b/test/glue/api_test.cljs
@@ -63,4 +63,7 @@
   (testing :delete-state
     (let [config {:state (fn [] {:state-one (glue/atom :one)})
                   :template "#template-id"}]
-      (is (nil? (:state (glue/convert-component-config config)))))))
+      (is (nil? (:state (glue/convert-component-config config))))))
+  (testing :without-state
+    (let [config {:template "#template-id"}]
+      (glue/convert-component-config config))))


### PR DESCRIPTION
`:state` should be a function, but default value of `:state` is `{}`